### PR TITLE
Fixed Entity PressurePlate will triggered by Ghost

### DIFF
--- a/Ahorn/entities/pressurePlate.jl
+++ b/Ahorn/entities/pressurePlate.jl
@@ -2,7 +2,7 @@ module FactoryHelperPressurePlate
 
 using ..Ahorn, Maple
 
-@mapdef Entity "FactoryHelper/PressurePlate" PressurePlate(x::Integer, y::Integer, activationIds::String="")
+@mapdef Entity "FactoryHelper/PressurePlate" PressurePlate(x::Integer, y::Integer, activationIds::String="", multiplayerMode::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Pressure Plate (FactoryHelper)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -93,6 +93,7 @@ placements.entities.FactoryHelper/PowerLine.tooltips.startActive=If `true` the e
 placements.entities.FactoryHelper/PowerLine.tooltips.colorCode=Hex color code (example: ff0000 is red) for the power line's power color, in both active and inactive state. Inactive is a dimmer version of this hex color.
 placements.entities.FactoryHelper/PowerLine.tooltips.initialDelay=The time it takes for the power line to switch states after it is activated.
 placements.entities.FactoryHelper/PressurePlate.tooltips.activationIds=A comma-separated list of all the activator IDs this button should set when pressed.
+placements.entities.FactoryHelper/PressurePlate.tooltips.multiplayerMode=If `true`, this button can be activate by Others from CelesteNet.
 
 # Rusty Lamp
 placements.entities.FactoryHelper/RustyLamp.tooltips.activationId=String value of the entity's activator ID. When a factory activator with this ID is turned on, the entity will toggle state.

--- a/Loenn/entities/pressure_plate.lua
+++ b/Loenn/entities/pressure_plate.lua
@@ -9,6 +9,7 @@ pressurePlate.placements = {
     name = "pressure_plate",
     data = {
         activationIds = ""
+        multiplayerMode = false
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -136,6 +136,8 @@ entities.FactoryHelper/PowerLine.attributes.description.initialDelay=The time in
 # Pressure Plate
 entities.FactoryHelper/PressurePlate.placements.name.pressure_plate=Pressure Plate
 entities.FactoryHelper/PressurePlate.attributes.description.activationIds=A comma-separated list of all the activator IDs this button should set when pressed.
+entities.FactoryHelper/PressurePlate.attributes.description.multiplayerMode=If `true`, this button can be activate by Others from CelesteNet.
+
 
 # Rust Berry
 entities.FactoryHelper/RustBerry.placements.name.rust_berry=Rusty Berry


### PR DESCRIPTION
Fixed Entity Pressure Plate will be triggered by Others from CelesteNet 
Added multiplayerMode Value for PressurePlate, that make Pressure Plate can triggered by Others from CelesteNet