### PR TITLE
fix potential divide by 0 crash

### DIFF
--- a/Code/Entities/Piston.cs
+++ b/Code/Entities/Piston.cs
@@ -419,7 +419,9 @@ namespace FactoryHelper.Entities {
                         player = _body.GetPlayerClimbing();
                         if (player != null) {
                             float newY = _base.Y + _grabPositionModifier + ((player.Y - (_base.Y + _grabPositionModifier)) * heightAfter / heightBefore);
-                            player.LiftSpeed = new Vector2(player.LiftSpeed.X, (newY - player.Y) / Engine.DeltaTime);
+                            if (Engine.DeltaTime != 0) {
+                                player.LiftSpeed = new Vector2(player.LiftSpeed.X, (newY - player.Y) / Engine.DeltaTime);
+                            }
                             player.MoveV(newY - player.Y);
                         }
                     }
@@ -442,7 +444,9 @@ namespace FactoryHelper.Entities {
                         player = _body.GetPlayerOnTop();
                         if (player != null) {
                             float newX = _base.X + _grabPositionModifier + ((player.X - (_base.X + _grabPositionModifier)) * widthAfter / widthBefore);
-                            player.LiftSpeed = new Vector2((newX - player.X) / Engine.DeltaTime, player.LiftSpeed.Y);
+                            if (Engine.DeltaTime != 0) {
+                                player.LiftSpeed = new Vector2((newX - player.X) / Engine.DeltaTime, player.LiftSpeed.Y);
+                            }
                             player.MoveH(newX - player.X);
                         }
                     }


### PR DESCRIPTION
This just adds an if case to make sure that the liftboost checks if `Engine.DeltaTime` isn't 0 before dividing by it. This fixes a crash with crystalline helper because the crystalline helper timestop sets `Engine.DeltaTime` to 0.