### PR TITLE
Improve Factory Activation Trigger

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -110,9 +110,10 @@ placements.entities.FactoryHelper/WindTunnel.tooltips.particleColors=Hex colors 
 
 # -- Triggers --
 # Factory Activation Trigger
+placements.triggers.FactoryHelper/FactoryActivationTrigger.tooltips.mode=The mode of this trigger.\nActivate: will activate all entities with the given activator IDs.\nDeactivate: will deactivate all entities with the given activator IDs.
 placements.triggers.FactoryHelper/FactoryActivationTrigger.tooltips.activationIds=A comma-separated list of all the activator IDs this trigger should set.
 placements.triggers.FactoryHelper/FactoryActivationTrigger.tooltips.ownActivationId=String value of the trigger's activator ID. Can only fire if the ID is active.
-placements.triggers.FactoryHelper/FactoryActivationTrigger.tooltips.resetOnLeave=Determines whether the IDs activated should be reset to their previous state upon leaving. If persistent is true this will be ignored.
+placements.triggers.FactoryHelper/FactoryActivationTrigger.tooltips.lockState=Whether the activated entities should have their states locked after using the trigger.\nIf true, other activators will not affect those entities after the trigger is used until a retry.
 placements.triggers.FactoryHelper/FactoryActivationTrigger.tooltips.persistent=Determines whether the IDs not already persistent that are governed by this trigger should become persistent, meaning they will be active even after leaving the room.
 
 # Factory Event Trigger

--- a/Ahorn/triggers/factoryActivationTrigger.jl
+++ b/Ahorn/triggers/factoryActivationTrigger.jl
@@ -2,7 +2,7 @@ module FactoryHelperFactoryActivationTrigger
 
 using ..Ahorn, Maple
 
-@mapdef Trigger "FactoryHelper/FactoryActivationTrigger" FactoryActivationTrigger(x::Integer, y::Integer, width::Integer=16, height::Integer=16, activationIds::String="", ownActivationId::String="", resetOnLeave::Bool=false, persistent::Bool=false)
+@mapdef Trigger "FactoryHelper/FactoryActivationTrigger" FactoryActivationTrigger(x::Integer, y::Integer, width::Integer=16, height::Integer=16, mode::String="Activate", activationId::String="", activationIds::String="", ownActivationId::String="", lockState::Bool=true, persistent::Bool=false)
 
 const placements = Ahorn.PlacementDict(
     "Factory Activation Trigger (FactoryHelper)" => Ahorn.EntityPlacement(

--- a/Code/Triggers/FactoryActivationTrigger.cs
+++ b/Code/Triggers/FactoryActivationTrigger.cs
@@ -8,17 +8,18 @@ using System.Collections.Generic;
 namespace FactoryHelper.Triggers {
     [CustomEntity("FactoryHelper/FactoryActivationTrigger")]
     public class FactoryActivationTrigger : Trigger {
-        private readonly bool _resetOnLeave;
+        private readonly bool _lockState;
         private readonly bool _persistent;
-        private readonly HashSet<string> _activationIds = new();
-        private bool _hasFired;
+        private readonly ActivationModes _mode;
+        private readonly HashSet<string> _activationIds = [];
 
         public FactoryActivationTrigger(EntityData data, Vector2 offset) 
             : base(data, offset) {
             string[] activationIds = data.Attr("activationIds", "").Split(',');
 
             _persistent = data.Bool("persistent", false);
-            _resetOnLeave = !_persistent && data.Bool("resetOnLeave", false);
+            _lockState = data.Bool("lockState", true);
+            _mode = data.Enum("mode", ActivationModes.Activate);
             Add(Activator = new FactoryActivator());
             Activator.ActivationId = data.Attr("ownActivationId") == string.Empty ? null : data.Attr("ownActivationId");
             Activator.StartOn = Activator.ActivationId == null;
@@ -30,48 +31,43 @@ namespace FactoryHelper.Triggers {
             }
         }
 
+        private enum ActivationModes {
+            Activate,
+            Deactivate
+        }
+
         public FactoryActivator Activator { get; }
 
         public override void OnEnter(Player player) {
             base.OnEnter(player);
-            if (Activator.IsOn && (!_hasFired || _resetOnLeave)) {
-                SetSessionTags(true);
-                SendOutSignals(true);
-                _hasFired = true;
-            }
-        }
-
-        public override void OnLeave(Player player) {
-            base.OnLeave(player);
-            if (Activator.IsOn && _resetOnLeave) {
-                SetSessionTags(false);
-                SendOutSignals(false);
+            if (Activator.IsOn) {
+                SetSessionTags(_mode);
+                SendOutSignals(_mode);
             }
         }
 
         public override void Added(Scene scene) {
             base.Added(scene);
             Activator.HandleStartup(scene);
-
         }
 
-        private void SendOutSignals(bool activating = true) {
+        private void SendOutSignals(ActivationModes mode) {
             foreach (FactoryActivator activator in Scene.Tracker.GetComponents<FactoryActivator>()) {
                 if (_activationIds.Contains(activator.ActivationId)) {
-                    if (activating) {
-                        activator.Activate();
-                    } else {
-                        activator.Deactivate();
+                    if (mode == ActivationModes.Activate) {
+                        activator.Activate(_lockState);
+                    } else if (mode == ActivationModes.Deactivate) {
+                        activator.Deactivate(_lockState);
                     }
                 }
             }
         }
 
-        private void SetSessionTags(bool activating = true) {
+        private void SetSessionTags(ActivationModes mode) {
             if (_persistent) {
                 Level level = Scene as Level;
                 foreach (string activationId in _activationIds) {
-                    level.Session.SetFlag($"FactoryActivation:{activationId}", activating);
+                    level.Session.SetFlag($"FactoryActivation:{activationId}", mode == ActivationModes.Activate);
                 }
             }
         }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -168,9 +168,10 @@ entities.FactoryHelper/WindTunnel.attributes.description.particleColors=Hex colo
 # -- Triggers --
 # Factory Activation Trigger
 triggers.FactoryHelper/FactoryActivationTrigger.placements.name.factory_activation=Factory Activation
+triggers.FactoryHelper/FactoryActivationTrigger.attributes.description.mode=The mode of this trigger.\nActivate: will activate all entities with the given activator IDs.\nDeactivate: will deactivate all entities with the given activator IDs.
 triggers.FactoryHelper/FactoryActivationTrigger.attributes.description.activationIds=A comma-separated list of all the activator IDs this trigger should set.
 triggers.FactoryHelper/FactoryActivationTrigger.attributes.description.ownActivationId=String value of the trigger's activator ID. Can only fire if the ID is active.
-triggers.FactoryHelper/FactoryActivationTrigger.attributes.description.resetOnLeave=Determines whether the IDs activated should be reset to their previous state upon leaving. If persistent is true this will be ignored.
+triggers.FactoryHelper/FactoryActivationTrigger.attributes.description.lockState=Whether the activated entities should have their states locked after using the trigger.\nIf true, other activators will not affect those entities after the trigger is used until a retry.
 triggers.FactoryHelper/FactoryActivationTrigger.attributes.description.persistent=Determines whether the IDs not already persistent that are governed by this trigger should become persistent, meaning they will be active even after leaving the room.
 
 # Factory Event Trigger

--- a/Loenn/triggers/factory_activation.lua
+++ b/Loenn/triggers/factory_activation.lua
@@ -1,13 +1,25 @@
 local factoryActivation = {}
 
+local modes = {
+    "Activate",
+    "Deactivate"
+}
+
 factoryActivation.name = "FactoryHelper/FactoryActivationTrigger"
 factoryActivation.placements = {
     name = "factory_activation",
     data = {
+        mode = "Activate",
         activationIds = "",
         ownActivationId = "",
-        resetOnLeave = false,
+        lockState = true,
         persistent = false
+    }
+}
+factoryActivation.fieldInformation = {
+    mode = {
+        editable = false,
+        options = modes
     }
 }
 


### PR DESCRIPTION
The current trigger has a broken field and some confusing behavior.

- remove "reset on leave" field (did not actually function)
- added a mode field for activate/deactivate
- added a "lock state" field to prevent entities changing state after the trigger is used

The default behavior before this was essentially Activate + lock state, this change exposes those options and adds flexibility

This also closes #8 